### PR TITLE
Fix game-speed bug

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 import CollisionBlock from "./utils/CollisionBlock.js"
 import Player from "./sprites/player.js"
 import Sprite from "./sprites/sprite.js"
+import Launcher from "./utils/Launcher.js";
 canvas.width = 1024
 canvas.height = 576
 
@@ -142,7 +143,6 @@ const camera = {
 
 
 function animate() {
-    window.requestAnimationFrame(animate)
     c.fillStyle = 'white'
     c.fillRect(0, 0, canvas.width, canvas.height)
     //player.draw()
@@ -216,7 +216,7 @@ function animate() {
     /*----------------------*/
 }
 
-animate()
+Launcher.launchGame(60, animate)
 
 
 window.addEventListener('keydown', (event) => {

--- a/utils/Launcher.js
+++ b/utils/Launcher.js
@@ -1,4 +1,9 @@
 export default class Launcher {
+    /**
+     *
+     * @param fps the custom game speed
+     * @param animateFunc the drawing function
+     */
     static launchGame(fps, animateFunc) {
 
         let fpsInterval, startTime, now, then, elapsed;

--- a/utils/Launcher.js
+++ b/utils/Launcher.js
@@ -1,0 +1,37 @@
+export default class Launcher {
+    static launchGame(fps, animateFunc) {
+
+        let fpsInterval, startTime, now, then, elapsed;
+        function tick(animateFunc) {
+
+            // request another frame
+
+            requestAnimationFrame(() => {
+                tick(animateFunc)
+            });
+
+            // calc elapsed time since last loop
+
+            now = Date.now();
+            elapsed = now - then;
+
+            // if enough time has elapsed, draw the next frame
+
+            if (elapsed > fpsInterval) {
+
+                // Get ready for next frame by setting then=now, but also adjust for your
+                // specified fpsInterval not being a multiple of RAF's interval (16.7ms)
+                then = now - (elapsed % fpsInterval);
+
+                // Put your drawing code here
+                animateFunc()
+            }
+        }
+
+        fpsInterval = 1000 / fps;
+        then = Date.now();
+        startTime = then;
+        tick(animateFunc);
+
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fix the bug game speed being bound to the display rate. See details in #8 .

## How does the PR fix the bug?

I create a `Launcher` class with a static method `#launchGame`. Now the game must be launched with the method. 

### How to use `Launcher#launchGame`?

The method consume two args, `fps` and `animateFunc`.
- `fps`: Costom your excepted gamespeed. The speed won't be faster than you screen refresh rate.
- `animateFunc`: Your drawing function.